### PR TITLE
Fixes enemy intents with posture.

### DIFF
--- a/src/main/java/the_warlord/powers/PosturePower.java
+++ b/src/main/java/the_warlord/powers/PosturePower.java
@@ -2,6 +2,7 @@ package the_warlord.powers;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.mod.stslib.powers.interfaces.OnReceivePowerPower;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.ReducePowerAction;
 import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
@@ -90,6 +91,11 @@ public int onAttackedToChangeDamage(DamageInfo info, int damageAmount) {
     }
     return damageTaken < 0 ? 0 : damageTaken;
 }
+
+    @Override
+    public float atDamageReceive(float damage, DamageInfo.DamageType type) {
+        return type == DamageInfo.DamageType.NORMAL ? damage - amount : damage - amount;
+    }
 
     @Override
     public void atStartOfTurn() {


### PR DESCRIPTION
Before this commit, enemies would show their regular intent damage even though you had posture.

This fixes that, as whenever posture is gained, the correct intent damage is shown.

However, there is one current problem with this method, where relics that give posture [fencing boots for example], do not initially show the correct intent amount.  It seems to only change the intent amount after more posture is gained.

