### PR TITLE
v0.0.12 - Tension-filled balance changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>stswarlordmod</groupId>
     <artifactId>WarlordMod</artifactId>
     <name>The Warlord</name>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
     <description>The Warlord, a character mod by the StS community.</description>
 
     <properties>

--- a/src/main/java/the_warlord/actions/AblutionCleanseDebuffsAction.java
+++ b/src/main/java/the_warlord/actions/AblutionCleanseDebuffsAction.java
@@ -1,0 +1,33 @@
+package the_warlord.actions;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.GainBlockAction;
+import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+
+import java.util.Iterator;
+
+public class AblutionCleanseDebuffsAction extends AbstractGameAction {
+    private AbstractCreature c;
+    private int block;
+
+    public AblutionCleanseDebuffsAction(AbstractCreature c, int block) {
+        this.c = c;
+        this.duration = 0.5F;
+        this.block = block;
+    }
+
+    public void update() {
+        Iterator var1 = this.c.powers.iterator();
+
+        while(var1.hasNext()) {
+            AbstractPower p = (AbstractPower)var1.next();
+            if (p.type == AbstractPower.PowerType.DEBUFF) {
+                this.addToTop(new RemoveSpecificPowerAction(this.c, this.c, p.ID));
+                addToTop(new GainBlockAction(this.c, this.block));
+            }
+        }
+        this.isDone = true;
+    }
+}

--- a/src/main/java/the_warlord/actions/AblutionCleanseDebuffsAction.java
+++ b/src/main/java/the_warlord/actions/AblutionCleanseDebuffsAction.java
@@ -19,10 +19,7 @@ public class AblutionCleanseDebuffsAction extends AbstractGameAction {
     }
 
     public void update() {
-        Iterator var1 = this.c.powers.iterator();
-
-        while(var1.hasNext()) {
-            AbstractPower p = (AbstractPower)var1.next();
+        for (AbstractPower p: c.powers){
             if (p.type == AbstractPower.PowerType.DEBUFF) {
                 this.addToTop(new RemoveSpecificPowerAction(this.c, this.c, p.ID));
                 addToTop(new GainBlockAction(this.c, this.block));

--- a/src/main/java/the_warlord/cards/warlord/Ambush.java
+++ b/src/main/java/the_warlord/cards/warlord/Ambush.java
@@ -2,7 +2,10 @@ package the_warlord.cards.warlord;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
+import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.actions.common.DamageAllEnemiesAction;
+import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
+import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
@@ -11,40 +14,35 @@ import the_warlord.WarlordMod;
 import the_warlord.cards.CustomWarlordModCard;
 import the_warlord.characters.Warlord;
 
+import static the_warlord.util.IntentUtils.isAttackIntent;
+
 public class Ambush extends CustomWarlordModCard {
     public static final String ID = WarlordMod.makeID(Ambush.class);
 
     private static final CardRarity RARITY = CardRarity.UNCOMMON;
-    private static final CardTarget TARGET = CardTarget.ALL_ENEMY;
+    private static final CardTarget TARGET = CardTarget.ENEMY;
     private static final CardType TYPE = CardType.ATTACK;
     public static final CardColor COLOR = Warlord.Enums.WARLORD_CARD_COLOR;
 
     private static final int COST = 1;
-    private static final int DAMAGE = 13;
+    private static final int DAMAGE = 10;
     private static final int UPGRADE_PLUS_DAMAGE = 3;
+    private static final int ENERGY = 1;
 
     public Ambush() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         baseDamage = DAMAGE;
 //        AutoplayField.autoplay.set(this, true);
         this.exhaust = true;
-        this.isMultiDamage = true;
     }
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        if (AbstractDungeon.actionManager.cardsPlayedThisTurn.size() - 1 == 0) {
-
-            addToBot(new VFXAction(new DaggerSprayEffect(AbstractDungeon.getMonsters().shouldFlipVfx()), 0.0F));
-            addToBot(new DamageAllEnemiesAction(AbstractDungeon.player, this.multiDamage, this.damageTypeForTurn, AbstractGameAction.AttackEffect.NONE));
+        addToBot(new DamageAction(m, new DamageInfo(p, damage), AbstractGameAction.AttackEffect.BLUNT_LIGHT));
+        if (!isAttackIntent(m.intent)) {
+            addToBot(new GainEnergyAction(ENERGY));
         }
     }
-
-    @Override
-    public boolean shouldGlowGold() {
-        return AbstractDungeon.actionManager.cardsPlayedThisTurn.size() == 0;
-    }
-
 
     @Override
     public void upgrade() {

--- a/src/main/java/the_warlord/cards/warlord/Ambush.java
+++ b/src/main/java/the_warlord/cards/warlord/Ambush.java
@@ -13,8 +13,10 @@ import com.megacrit.cardcrawl.vfx.combat.DaggerSprayEffect;
 import the_warlord.WarlordMod;
 import the_warlord.cards.CustomWarlordModCard;
 import the_warlord.characters.Warlord;
+import the_warlord.util.IntentUtils;
 
 import static the_warlord.util.IntentUtils.isAttackIntent;
+import static the_warlord.util.IntentUtils.playerCanSeeThatAnyEnemyIntentMatches;
 
 public class Ambush extends CustomWarlordModCard {
     public static final String ID = WarlordMod.makeID(Ambush.class);
@@ -33,7 +35,6 @@ public class Ambush extends CustomWarlordModCard {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         baseDamage = DAMAGE;
 //        AutoplayField.autoplay.set(this, true);
-        this.exhaust = true;
     }
 
     @Override
@@ -52,4 +53,6 @@ public class Ambush extends CustomWarlordModCard {
             upgradeDescription();
         }
     }
+
+    public boolean shouldGlowGold() { return IntentUtils.playerCanSeeThatAnyEnemyIntentMatches(IntentUtils::isAttackIntent); }
 }

--- a/src/main/java/the_warlord/cards/warlord/Anticoagulant.java
+++ b/src/main/java/the_warlord/cards/warlord/Anticoagulant.java
@@ -1,37 +1,43 @@
 package the_warlord.cards.warlord;
 
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import the_warlord.WarlordMod;
 import the_warlord.actions.DoubleBleedAction;
 import the_warlord.cards.CustomWarlordModCard;
 import the_warlord.characters.Warlord;
+import the_warlord.powers.AnticoagulantPower;
+import the_warlord.powers.PunishmentPower;
 
 public class Anticoagulant extends CustomWarlordModCard {
     public static final String ID = WarlordMod.makeID(Anticoagulant.class);
 
     private static final CardRarity RARITY = CardRarity.UNCOMMON;
-    private static final CardTarget TARGET = CardTarget.ENEMY;
+    private static final CardTarget TARGET = CardTarget.SELF;
     private static final CardType TYPE = CardType.SKILL;
     public static final CardColor COLOR = Warlord.Enums.WARLORD_CARD_COLOR;
 
     private static final int COST = 1;
+    private static final int UPGRADED_COST = 0;
+    private static final int GUSH = 2;
 
     public Anticoagulant() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
-        this.exhaust = true;
+        this.magicNumber = this.baseMagicNumber = GUSH;
     }
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        if(upgraded){ addToBot(new DoubleBleedAction(m, p, true)); }
-        else { addToBot(new DoubleBleedAction(m, p, false)); }
+        addToBot(new ApplyPowerAction(p, p, new AnticoagulantPower(p, this.magicNumber)));
     }
 
     @Override
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
+            upgradeBaseCost(UPGRADED_COST);
+            //upgradeBaseCost(UPGRADED_COST);
             upgradeDescription();
         }
     }

--- a/src/main/java/the_warlord/cards/warlord/Extremespeed.java
+++ b/src/main/java/the_warlord/cards/warlord/Extremespeed.java
@@ -19,9 +19,9 @@ public class Extremespeed extends CustomWarlordModCard {
 
     private static final int COST = 0;
     private static final int UPGRADED_COST = 0;
-    private static final int DRAW = 5;
+    private static final int DRAW = 3;
     private static final int UPGRADE_PLUS_DRAW = 1;
-    private static final int DAZED = 2;
+    private static final int DAZED = 1;
 
     public Extremespeed() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
@@ -32,8 +32,7 @@ public class Extremespeed extends CustomWarlordModCard {
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-
-        addToBot(new DiscardHandAction());
+        //addToBot(new DiscardHandAction());
         addToBot(new DrawCardAction(urMagicNumber));
         addToBot(new MakeTempCardInDrawPileAction(new Dizzy(), magicNumber, true, true));
     }

--- a/src/main/java/the_warlord/cards/warlord/Extremespeed.java
+++ b/src/main/java/the_warlord/cards/warlord/Extremespeed.java
@@ -21,11 +21,11 @@ public class Extremespeed extends CustomWarlordModCard {
     private static final int UPGRADED_COST = 0;
     private static final int DRAW = 3;
     private static final int UPGRADE_PLUS_DRAW = 1;
-    private static final int DAZED = 1;
+    private static final int DIZZY = 1;
 
     public Extremespeed() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
-        magicNumber = baseMagicNumber = DAZED;
+        magicNumber = baseMagicNumber = DIZZY;
         urMagicNumber = baseUrMagicNumber = DRAW;
         cardsToPreview = new Dizzy();
     }

--- a/src/main/java/the_warlord/cards/warlord/FocusPunch.java
+++ b/src/main/java/the_warlord/cards/warlord/FocusPunch.java
@@ -16,10 +16,10 @@ public class FocusPunch extends CustomWarlordModCard {
     private static final CardType TYPE = CardType.ATTACK;
     public static final CardColor COLOR = Warlord.Enums.WARLORD_CARD_COLOR;
 
-    private static final int COST = 3;
-    private static final int DAMAGE = 30;
-    private static final int UPGRADE_PLUS_DAMAGE = 10;
-    private static final int TENSION = 5;
+    private static final int COST = 1;
+    private static final int DAMAGE = 16;
+    private static final int UPGRADE_PLUS_DAMAGE = 4;
+    private static final int TENSION = 2;
 
     public FocusPunch() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);

--- a/src/main/java/the_warlord/cards/warlord/FocusPunch.java
+++ b/src/main/java/the_warlord/cards/warlord/FocusPunch.java
@@ -29,7 +29,7 @@ public class FocusPunch extends CustomWarlordModCard {
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        addToBot(new ApplyPowerAction(p, p, new FocusPunchPower(p, damage, m)));
+        addToBot(new ApplyPowerAction(p, p, new FocusPunchPower(p, damage, m, magicNumber)));
     }
 
     @Override

--- a/src/main/java/the_warlord/cards/warlord/Safeguard.java
+++ b/src/main/java/the_warlord/cards/warlord/Safeguard.java
@@ -1,5 +1,6 @@
 package the_warlord.cards.warlord;
 
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.GainBlockAction;
 import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
@@ -19,20 +20,23 @@ public class Safeguard extends CustomWarlordModCard {
     public static final CardColor COLOR = Warlord.Enums.WARLORD_CARD_COLOR;
 
     private static final int COST = 2;
-    private static final int BLOCK = 14;
-    private static final int UPGRADE_PLUS_BLOCK = 4;
-
+    private static final int BLOCK = 13;
+    private static final int UPGRADE_PLUS_BLOCK = 3;
+    private static final int TENSION_LOSS = 2;
+    private static final int UPGRADE_TENSION_LOSS = 1;
 
     public Safeguard() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         block = baseBlock = BLOCK;
+        magicNumber = baseMagicNumber = TENSION_LOSS;
     }
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
         addToBot(new GainBlockAction(p, block));
-        if (p.hasPower(TensionPower.POWER_ID)) {
-            addToBot(new RemoveSpecificPowerAction(p, p, TensionPower.POWER_ID));
+        if(p.hasPower(TensionPower.POWER_ID)){
+            if(p.getPower(TensionPower.POWER_ID).amount != this.magicNumber){ addToBot(new ApplyPowerAction(p, p, new TensionPower(p, -magicNumber), -magicNumber)); }
+            else { addToBot(new RemoveSpecificPowerAction(p, p, TensionPower.POWER_ID)); }
         }
     }
 
@@ -40,6 +44,7 @@ public class Safeguard extends CustomWarlordModCard {
     public void upgrade() {
         if (!upgraded) {
             upgradeBlock(UPGRADE_PLUS_BLOCK);
+            upgradeMagicNumber(UPGRADE_TENSION_LOSS);
             upgradeName();
             upgradeDescription();
         }

--- a/src/main/java/the_warlord/cards/warlord/Steamroll.java
+++ b/src/main/java/the_warlord/cards/warlord/Steamroll.java
@@ -1,30 +1,36 @@
 package the_warlord.cards.warlord;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.AttackDamageRandomEnemyAction;
+import com.megacrit.cardcrawl.actions.common.DamageAction;
+import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
 import the_warlord.WarlordMod;
 import the_warlord.cards.CustomWarlordModCard;
 import the_warlord.characters.Warlord;
+import the_warlord.powers.BleedPower;
 
 public class Steamroll extends CustomWarlordModCard {
     public static final String ID = WarlordMod.makeID(Steamroll.class);
 
     private static final CardRarity RARITY = CardRarity.UNCOMMON;
-    private static final CardTarget TARGET = CardTarget.ALL_ENEMY;
+    private static final CardTarget TARGET = CardTarget.ENEMY;
     private static final CardType TYPE = CardType.ATTACK;
     public static final CardColor COLOR = Warlord.Enums.WARLORD_CARD_COLOR;
 
     private static final int COST = COST_X;
-    private static final int DAMAGE = 9;
-    private static final int UPGRADE_PLUS_DAMAGE = 3;
+    private static final int DAMAGE = 6;
+    private static final int UPGRADE_PLUS_DAMAGE = 2;
+    private static final int BLEED = 2;
+    private static final int UPGRADE_PLUS_BLEED = 1;
 
     public Steamroll() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         baseDamage = DAMAGE;
-        this.exhaust = true;
+        this.magicNumber = this.baseMagicNumber = BLEED;
     }
 
     @Override
@@ -41,7 +47,9 @@ public class Steamroll extends CustomWarlordModCard {
         }
 
         for (int i = 0; i < effect; ++i) {
-            this.addToBot(new AttackDamageRandomEnemyAction(this, AbstractGameAction.AttackEffect.BLUNT_HEAVY));
+            //this.addToBot(new AttackDamageRandomEnemyAction(this, AbstractGameAction.AttackEffect.BLUNT_HEAVY));
+            addToBot(new DamageAction(m, new DamageInfo(p, damage), AbstractGameAction.AttackEffect.BLUNT_HEAVY));
+            addToBot(new ApplyPowerAction(m, m, new BleedPower(m, this.magicNumber)));
         }
 
         if (!this.freeToPlayOnce) {
@@ -53,7 +61,7 @@ public class Steamroll extends CustomWarlordModCard {
     public void upgrade() {
         if (!upgraded) {
             upgradeDamage(UPGRADE_PLUS_DAMAGE);
-
+            upgradeMagicNumber(UPGRADE_PLUS_BLEED);
             upgradeName();
             upgradeDescription();
         }

--- a/src/main/java/the_warlord/cards/warlord/StunNeedle.java
+++ b/src/main/java/the_warlord/cards/warlord/StunNeedle.java
@@ -22,7 +22,7 @@ public class StunNeedle extends CustomWarlordModCard {
 
     private static final int COST = 1;
     private static final int UPGRADED_COST = 0;
-    private static final int DAMAGE = 4;
+    private static final int DAMAGE = 7;
     private static final int STRENGTH_LOSS = 1;
     private static final int COST_INCREASE = 1;
 

--- a/src/main/java/the_warlord/cards/warlord/TopsyTurvy.java
+++ b/src/main/java/the_warlord/cards/warlord/TopsyTurvy.java
@@ -6,6 +6,7 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import the_warlord.WarlordMod;
 import the_warlord.cards.CustomWarlordModCard;
 import the_warlord.characters.Warlord;
+import the_warlord.powers.PosturePower;
 import the_warlord.powers.TenseUpPower;
 
 public class TopsyTurvy extends CustomWarlordModCard {
@@ -17,12 +18,12 @@ public class TopsyTurvy extends CustomWarlordModCard {
     public static final CardColor COLOR = Warlord.Enums.WARLORD_CARD_COLOR;
 
     private static final int COST = 1;
-    private static final int BLOCK_PER_TENSION = 4;
-    private static final int UPGRADE_BLOCK_PER_TENSION = 2;
+    private static final int POSTURE_PER_TENSION = 1;
+    private static final int UPGRADE_POSTURE_PER_TENSION = 1;
 
     public TopsyTurvy() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
-        this.magicNumber = this.baseMagicNumber = BLOCK_PER_TENSION;
+        this.magicNumber = this.baseMagicNumber = POSTURE_PER_TENSION;
     }
 
     @Override
@@ -34,7 +35,7 @@ public class TopsyTurvy extends CustomWarlordModCard {
     @Override
     public void upgrade() {
         if (!upgraded) {
-            upgradeMagicNumber(UPGRADE_BLOCK_PER_TENSION);
+            upgradeMagicNumber(UPGRADE_POSTURE_PER_TENSION);
 
             upgradeName();
             upgradeDescription();

--- a/src/main/java/the_warlord/cards/warlord/TrappingPit.java
+++ b/src/main/java/the_warlord/cards/warlord/TrappingPit.java
@@ -29,7 +29,6 @@ public class TrappingPit extends CustomWarlordModCard {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         magicNumber = baseMagicNumber = BLEED;
         urMagicNumber = baseUrMagicNumber = WEAK;
-
     }
 
     @Override
@@ -51,6 +50,7 @@ public class TrappingPit extends CustomWarlordModCard {
         if (!upgraded) {
             upgradeName();
             upgradeMagicNumber(UPGRADE_PLUS_BLEED);
+            this.selfRetain = true;
             upgradeDescription();
         }
     }

--- a/src/main/java/the_warlord/cards/warlord/parry_deck/Ablution.java
+++ b/src/main/java/the_warlord/cards/warlord/parry_deck/Ablution.java
@@ -1,12 +1,16 @@
 package the_warlord.cards.warlord.parry_deck;
 
+import basemod.ReflectionHacks;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.unique.RemoveDebuffsAction;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.powers.ArtifactPower;
 import the_warlord.WarlordMod;
 import the_warlord.actions.AblutionCleanseDebuffsAction;
 import the_warlord.characters.Warlord;
+import the_warlord.util.IntentUtils;
 
 public class Ablution extends CustomParryCard {
     public static final String ID = WarlordMod.makeID(Ablution.class);
@@ -24,11 +28,28 @@ public class Ablution extends CustomParryCard {
     public Ablution() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         block = baseBlock = BLOCK;
+        this.magicNumber = this.baseMagicNumber = 0;
     }
 
     @Override
     public void useParry() {
         addToBot(new AblutionCleanseDebuffsAction(AbstractDungeon.player, this.block));
+    }
+
+    @Override
+    public int calculateBonusMagicNumber() {
+        int debuffCleansed = 0;
+        for (AbstractPower p : AbstractDungeon.player.powers) {
+            if(p.type == AbstractPower.PowerType.DEBUFF){
+                ++debuffCleansed;
+            }
+        }
+        return debuffCleansed;
+    }
+
+    @Override
+    public String getRawDynamicDescriptionSuffix() {
+        return magicNumber == 1 ? EXTENDED_DESCRIPTION[0] : magicNumber > 1 ? EXTENDED_DESCRIPTION[1] : "";
     }
 
     @Override

--- a/src/main/java/the_warlord/cards/warlord/parry_deck/Ablution.java
+++ b/src/main/java/the_warlord/cards/warlord/parry_deck/Ablution.java
@@ -5,6 +5,7 @@ import com.megacrit.cardcrawl.actions.unique.RemoveDebuffsAction;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.ArtifactPower;
 import the_warlord.WarlordMod;
+import the_warlord.actions.AblutionCleanseDebuffsAction;
 import the_warlord.characters.Warlord;
 
 public class Ablution extends CustomParryCard {
@@ -16,26 +17,25 @@ public class Ablution extends CustomParryCard {
     public static final CardColor COLOR = Warlord.Enums.WARLORD_CARD_COLOR;
 
     private static final int COST = COST_UNPLAYABLE;
-    private static final int ARTIFACT = 1;
+    private static final int BLOCK = 3;
+    private static final int UPGRADE_PLUS_BLOCK = 1;
+
 
     public Ablution() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
-        magicNumber = baseMagicNumber = ARTIFACT;
+        block = baseBlock = BLOCK;
     }
 
     @Override
     public void useParry() {
-        addToBot(new RemoveDebuffsAction(AbstractDungeon.player));
-        if (upgraded) {
-            addToBot(new ApplyPowerAction(AbstractDungeon.player, AbstractDungeon.player, new ArtifactPower(AbstractDungeon.player, magicNumber)));
-        }
+        addToBot(new AblutionCleanseDebuffsAction(AbstractDungeon.player, this.block));
     }
 
     @Override
     public void upgrade() {
         if (!upgraded) {
-
             upgradeName();
+            upgradeBlock(UPGRADE_PLUS_BLOCK);
             upgradeDescription();
         }
     }

--- a/src/main/java/the_warlord/cards/warlord/parry_deck/DecisiveFactor.java
+++ b/src/main/java/the_warlord/cards/warlord/parry_deck/DecisiveFactor.java
@@ -1,7 +1,9 @@
 package the_warlord.cards.warlord.parry_deck;
 
 import com.megacrit.cardcrawl.actions.common.DrawCardAction;
+import com.megacrit.cardcrawl.actions.unique.ApotheosisAction;
 import com.megacrit.cardcrawl.actions.unique.ArmamentsAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
 import the_warlord.WarlordMod;
 import the_warlord.characters.Warlord;
 
@@ -24,9 +26,9 @@ public class DecisiveFactor extends CustomParryCard {
     @Override
     public void useParry() {
         if (this.upgraded) {
-            addToBot(new DrawCardAction(magicNumber));
+            addToBot(new ApotheosisAction());
         }
-        addToBot(new ArmamentsAction(true));
+        else { addToBot(new ArmamentsAction(true)); }
     }
 
     @Override

--- a/src/main/java/the_warlord/cards/warlord/parry_deck/DecisiveFactor.java
+++ b/src/main/java/the_warlord/cards/warlord/parry_deck/DecisiveFactor.java
@@ -27,6 +27,7 @@ public class DecisiveFactor extends CustomParryCard {
     public void useParry() {
         if (this.upgraded) {
             addToBot(new ApotheosisAction());
+            removeFromMasterParryDeck(this);
         }
         else { addToBot(new ArmamentsAction(true)); }
     }

--- a/src/main/java/the_warlord/cards/warlord/parry_deck/Wrap.java
+++ b/src/main/java/the_warlord/cards/warlord/parry_deck/Wrap.java
@@ -23,7 +23,7 @@ public class Wrap extends CustomParryCard {
     private static final int COST = COST_UNPLAYABLE;
 
     private static final int BLOCK = 5;
-    private static final int UPGRADE_PLUS_BLOCK = 8;
+    private static final int UPGRADE_PLUS_BLOCK = 3;
     private static final int TENSION_LOSS = 1;
 
     public Wrap() {
@@ -45,7 +45,7 @@ public class Wrap extends CustomParryCard {
     @Override
     public void upgrade() {
         if (!upgraded) {
-            upgradeMagicNumber(UPGRADE_PLUS_BLOCK);
+            upgradeBlock(UPGRADE_PLUS_BLOCK);
             upgradeName();
             upgradeDescription();
         }

--- a/src/main/java/the_warlord/cards/warlord/parry_deck/Wrap.java
+++ b/src/main/java/the_warlord/cards/warlord/parry_deck/Wrap.java
@@ -1,11 +1,16 @@
 package the_warlord.cards.warlord.parry_deck;
 
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.GainBlockAction;
+import com.megacrit.cardcrawl.actions.common.ReducePowerAction;
+import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.PlatedArmorPower;
 import the_warlord.WarlordMod;
 import the_warlord.characters.Warlord;
+import the_warlord.powers.TenseUpPower;
+import the_warlord.powers.TensionPower;
 
 public class Wrap extends CustomParryCard {
     public static final String ID = WarlordMod.makeID(Wrap.class);
@@ -17,26 +22,31 @@ public class Wrap extends CustomParryCard {
 
     private static final int COST = COST_UNPLAYABLE;
 
-    private static final int PLATED_ARMOR = 3;
-    private static final int UPGRADE_PLUS_PLATED_ARMOR = 1;
+    private static final int BLOCK = 5;
+    private static final int UPGRADE_PLUS_BLOCK = 8;
+    private static final int TENSION_LOSS = 1;
 
     public Wrap() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
-        magicNumber = baseMagicNumber = PLATED_ARMOR;
-
+        block = baseBlock = BLOCK;
+        magicNumber = baseMagicNumber = TENSION_LOSS;
     }
 
     @Override
     public void useParry() {
         AbstractPlayer p = AbstractDungeon.player;
-        addToBot(new ApplyPowerAction(p, p, new PlatedArmorPower(p, magicNumber)));
+        addToBot(new GainBlockAction(p, this.block));
+        if(p.hasPower(TensionPower.POWER_ID)){
+            if(p.getPower(TensionPower.POWER_ID).amount != this.magicNumber){ addToBot(new ApplyPowerAction(p, p, new TensionPower(p, -magicNumber), -magicNumber)); }
+            else { addToBot(new RemoveSpecificPowerAction(p, p, TensionPower.POWER_ID)); }
+
+        }
     }
 
     @Override
     public void upgrade() {
         if (!upgraded) {
-            upgradeMagicNumber(UPGRADE_PLUS_PLATED_ARMOR);
-
+            upgradeMagicNumber(UPGRADE_PLUS_BLOCK);
             upgradeName();
             upgradeDescription();
         }

--- a/src/main/java/the_warlord/cards/warlord/parry_deck/Wrap.java
+++ b/src/main/java/the_warlord/cards/warlord/parry_deck/Wrap.java
@@ -39,7 +39,6 @@ public class Wrap extends CustomParryCard {
         if(p.hasPower(TensionPower.POWER_ID)){
             if(p.getPower(TensionPower.POWER_ID).amount != this.magicNumber){ addToBot(new ApplyPowerAction(p, p, new TensionPower(p, -magicNumber), -magicNumber)); }
             else { addToBot(new RemoveSpecificPowerAction(p, p, TensionPower.POWER_ID)); }
-
         }
     }
 

--- a/src/main/java/the_warlord/powers/AnticoagulantPower.java
+++ b/src/main/java/the_warlord/powers/AnticoagulantPower.java
@@ -1,0 +1,45 @@
+package the_warlord.powers;
+
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.powers.VulnerablePower;
+
+public class AnticoagulantPower extends CustomWarlordModPower implements OnParrySubscriber {
+    public static final StaticPowerInfo STATIC = StaticPowerInfo.Load(AnticoagulantPower.class);
+    public static final String POWER_ID = STATIC.ID;
+
+    public AnticoagulantPower(AbstractCreature owner, int amount) {
+        super(STATIC);
+        this.type = PowerType.BUFF;
+        this.owner = owner;
+        this.amount = amount;
+        loadRegion("flameBarrier");
+        updateDescription();
+    }
+
+    @Override
+    public void updateDescription() {
+        description = String.format(DESCRIPTIONS[0], amount);
+    }
+
+    @Override
+    public AbstractPower makeCopy() {
+        return new PunishmentPower(owner, amount);
+    }
+
+    @Override
+    public void onParry(boolean fullParry) {
+        flash();
+        for (AbstractMonster monster : AbstractDungeon.getCurrRoom().monsters.monsters) {
+            if (!monster.isDead && !monster.isDying) {
+                addToBot(new ApplyPowerAction(monster, AbstractDungeon.player, new GushPower(monster, amount)));
+                addToBot(new RemoveSpecificPowerAction(AbstractDungeon.player, AbstractDungeon.player, this));
+            }
+        }
+
+    }
+}

--- a/src/main/java/the_warlord/powers/DoubleTeamPower.java
+++ b/src/main/java/the_warlord/powers/DoubleTeamPower.java
@@ -64,11 +64,8 @@ public class DoubleTeamPower extends CustomWarlordModPower {
 
     @Override
     public void updateDescription() {
-        if (this.amount == 1) {
-            this.description = DESCRIPTIONS[0];
-        } else {
-            description = String.format(DESCRIPTIONS[1], amount);
-        }
+        if (this.amount == 1) { this.description = DESCRIPTIONS[0];
+        } else { description = String.format(DESCRIPTIONS[1], amount); }
     }
 
     @Override

--- a/src/main/java/the_warlord/powers/FocusPunchPower.java
+++ b/src/main/java/the_warlord/powers/FocusPunchPower.java
@@ -15,18 +15,13 @@ public class FocusPunchPower extends CustomWarlordModPower {
     public static final String POWER_ID = STATIC.ID;
     private AbstractMonster target;
     private Boolean damageTaken;
-
     public FocusPunchPower(AbstractCreature owner, int amount, AbstractMonster target) {
         super(STATIC);
-
         this.type = PowerType.BUFF;
-
         this.target = target;
         this.owner = owner;
         this.amount = amount;
-
         this.damageTaken = false;
-
         updateDescription();
     }
 
@@ -35,7 +30,7 @@ public class FocusPunchPower extends CustomWarlordModPower {
         if (!damageTaken && info.owner != null && info.type != DamageInfo.DamageType.THORNS && info.type != DamageInfo.DamageType.HP_LOSS && info.owner != this.owner && damageAmount > 0) {
             flash();
             damageTaken = true;
-            addToBot(new ApplyPowerAction(owner, owner, new TensionPower(owner, 5)));
+            addToBot(new ApplyPowerAction(owner, owner, new TensionPower(owner, 2)));
 //            addToTop(new RemoveSpecificPowerAction(this.owner, this.owner, this));
         }
         return damageAmount;

--- a/src/main/java/the_warlord/powers/FocusPunchPower.java
+++ b/src/main/java/the_warlord/powers/FocusPunchPower.java
@@ -15,12 +15,13 @@ public class FocusPunchPower extends CustomWarlordModPower {
     public static final String POWER_ID = STATIC.ID;
     private AbstractMonster target;
     private Boolean damageTaken;
-    public FocusPunchPower(AbstractCreature owner, int amount, AbstractMonster target) {
+    public FocusPunchPower(AbstractCreature owner, int amount, AbstractMonster target, int amount2) {
         super(STATIC);
         this.type = PowerType.BUFF;
         this.target = target;
         this.owner = owner;
         this.amount = amount;
+        this.amount2 = amount2;
         this.damageTaken = false;
         updateDescription();
     }
@@ -30,7 +31,7 @@ public class FocusPunchPower extends CustomWarlordModPower {
         if (!damageTaken && info.owner != null && info.type != DamageInfo.DamageType.THORNS && info.type != DamageInfo.DamageType.HP_LOSS && info.owner != this.owner && damageAmount > 0) {
             flash();
             damageTaken = true;
-            addToBot(new ApplyPowerAction(owner, owner, new TensionPower(owner, 2)));
+            addToBot(new ApplyPowerAction(owner, owner, new TensionPower(owner, amount2)));
 //            addToTop(new RemoveSpecificPowerAction(this.owner, this.owner, this));
         }
         return damageAmount;
@@ -38,7 +39,7 @@ public class FocusPunchPower extends CustomWarlordModPower {
 
     @Override
     public void updateDescription() {
-        description = String.format(DESCRIPTIONS[0], amount);
+        description = String.format(DESCRIPTIONS[0], amount, amount2);
     }
 
     @Override
@@ -50,6 +51,6 @@ public class FocusPunchPower extends CustomWarlordModPower {
 
     @Override
     public AbstractPower makeCopy() {
-        return new FocusPunchPower(owner, amount, target);
+        return new FocusPunchPower(owner, amount, target, amount2);
     }
 }

--- a/src/main/java/the_warlord/powers/ParryPower.java
+++ b/src/main/java/the_warlord/powers/ParryPower.java
@@ -17,7 +17,7 @@ import the_warlord.relics.RelicParrySubscriber;
 
 import java.util.ArrayList;
 
-public class ParryPower extends CustomWarlordModPower implements InvisiblePower {
+public class ParryPower extends CustomWarlordModPower { //implements InvisiblePower {
     public static final StaticPowerInfo STATIC = StaticPowerInfo.Load(ParryPower.class);
     public static final String POWER_ID = STATIC.ID;
 
@@ -30,7 +30,7 @@ public class ParryPower extends CustomWarlordModPower implements InvisiblePower 
         this.type = PowerType.BUFF;
 
         this.owner = owner;
-
+        loadRegion("flameBarrier");
         updateDescription();
     }
 

--- a/src/main/java/the_warlord/powers/TenseUpPower.java
+++ b/src/main/java/the_warlord/powers/TenseUpPower.java
@@ -1,5 +1,6 @@
 package the_warlord.powers;
 
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.GainBlockAction;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.powers.AbstractPower;
@@ -28,7 +29,7 @@ public class TenseUpPower extends CustomWarlordModPower {
     public void onApplyPower(AbstractPower power, AbstractCreature target, AbstractCreature source) {
         if (power.ID.equals(TensionPower.POWER_ID)) {
             flash();
-            addToBot(new GainBlockAction(owner, amount));
+            addToBot(new ApplyPowerAction(this.owner, this.owner, new PosturePower(this.owner, this.amount)));
         }
     }
 

--- a/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Card-Strings.json
+++ b/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Card-Strings.json
@@ -149,7 +149,11 @@
   },
   "the_warlord:Ablution": {
     "NAME": "Ablution",
-    "DESCRIPTION": "Remove all of your debuffs. NL Gain !B! Block for each debuff removed."
+    "DESCRIPTION": "Remove all of your debuffs. NL Gain !B! Block for each debuff removed.",
+    "EXTENDED_DESCRIPTION": [
+      " NL (You have !M! Debuff.)",
+      " NL (You have !M! Debuffs.)"
+    ]
   },
   "the_warlord:HighStakes": {
     "NAME": "High Stakes",
@@ -158,10 +162,7 @@
   },
   "the_warlord:Ambush": {
     "NAME": "Ambush",
-    "DESCRIPTION": "Deal !D! damage. NL If the enemy is not attacking NL Gain [E]",
-    "EXTENDED_DESCRIPTION": [
-      ""
-    ]
+    "DESCRIPTION": "Deal !D! damage. NL If the enemy is not attacking NL Gain [E]"
   },
   "the_warlord:Assess": {
     "NAME": "Assess",
@@ -223,7 +224,7 @@
   "the_warlord:DecisiveFactor": {
     "NAME": "Decisive Factor",
     "DESCRIPTION": "Upgrade ALL cards in your hand for the rest of combat.",
-    "UPGRADE_DESCRIPTION": "Upgrade ALL cards in your deck, and ALL cards in your parry deck for the rest of combat."
+    "UPGRADE_DESCRIPTION": "Upgrade ALL cards for the rest of combat (including your parry cards) NL the_warlord:Purge."
   },
   "the_warlord:TakeShelter": {
     "NAME": "Take Shelter",

--- a/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Card-Strings.json
+++ b/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Card-Strings.json
@@ -295,7 +295,7 @@
   },
   "the_warlord:Safeguard": {
     "NAME": "Safeguard",
-    "DESCRIPTION": "Gain !B! Block. NL Remove all of your the_warlord:Tension."
+    "DESCRIPTION": "Gain !B! Block. NL Remove !M! the_warlord:Tension."
   },
   "the_warlord:SpeedUp": {
     "NAME": "Speed Up",

--- a/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Card-Strings.json
+++ b/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Card-Strings.json
@@ -75,7 +75,7 @@
   },
   "the_warlord:Wrap": {
     "NAME": "Wrap",
-    "DESCRIPTION": "Gain !M! Plated Armor."
+    "DESCRIPTION": "Gain !B! Block. NL Lose 1 the_warlord:Tension"
   },
   "the_warlord:HitNRun": {
     "NAME": "Hit 'n Run",
@@ -111,7 +111,7 @@
   },
   "the_warlord:TopsyTurvy": {
     "NAME": "Topsy-Turvy",
-    "DESCRIPTION": "Whenever you gain the_warlord:Tension, gain !M! Block."
+    "DESCRIPTION": "Whenever you gain the_warlord:Tension, gain !M! the_warlord:Posture."
   },
   "the_warlord:PositioningTheory": {
     "NAME": "Positioning Theory",
@@ -123,7 +123,7 @@
   },
   "the_warlord:Steamroll": {
     "NAME": "Steamroll",
-    "DESCRIPTION": "Deal !D! damage to a random enemy X times. NL Exhaust."
+    "DESCRIPTION": "Deal !D! damage and apply !M! the_warlord:Bleed X times."
   },
   "the_warlord:Furrow": {
     "NAME": "Furrow",
@@ -149,8 +149,7 @@
   },
   "the_warlord:Ablution": {
     "NAME": "Ablution",
-    "DESCRIPTION": "Remove all of your debuffs.",
-    "UPGRADE_DESCRIPTION": "Remove all of your debuffs. NL Gain !M! Artifact."
+    "DESCRIPTION": "Remove all of your debuffs. NL Gain !B! Block for each debuff removed."
   },
   "the_warlord:HighStakes": {
     "NAME": "High Stakes",
@@ -159,9 +158,9 @@
   },
   "the_warlord:Ambush": {
     "NAME": "Ambush",
-    "DESCRIPTION": "If this is the first card played this turn, deal !D! damage to ALL enemies. NL Exhaust.",
+    "DESCRIPTION": "Deal !D! damage. NL If the enemy is not attacking NL Gain [E]",
     "EXTENDED_DESCRIPTION": [
-      "I can't play this card."
+      ""
     ]
   },
   "the_warlord:Assess": {
@@ -223,8 +222,8 @@
   },
   "the_warlord:DecisiveFactor": {
     "NAME": "Decisive Factor",
-    "DESCRIPTION": "Upgrade all cards in your hand for the rest of combat.",
-    "UPGRADE_DESCRIPTION": "Draw !M! card. NL Upgrade all cards in your hand for the rest of combat."
+    "DESCRIPTION": "Upgrade ALL cards in your hand for the rest of combat.",
+    "UPGRADE_DESCRIPTION": "Upgrade ALL cards in your deck, and ALL cards in your parry deck for the rest of combat."
   },
   "the_warlord:TakeShelter": {
     "NAME": "Take Shelter",
@@ -283,8 +282,7 @@
   },
   "the_warlord:Anticoagulant": {
     "NAME": "Anticoagulant",
-    "DESCRIPTION": "Double the enemy's the_warlord:Bleed. NL Exhaust.",
-    "UPGRADE_DESCRIPTION": "Triple the enemy's the_warlord:Bleed. NL Exhaust."
+    "DESCRIPTION": "The next time you the_warlord:Parry, apply !M! the_warlord:Gush to ALL enemies."
   },
   "the_warlord:FocusPunch": {
     "NAME": "Focus Punch",

--- a/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Card-Strings.json
+++ b/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Card-Strings.json
@@ -309,7 +309,8 @@
 
   "the_warlord:TrappingPit": {
     "NAME": "Trapping Pit",
-    "DESCRIPTION": "Apply !M! the_warlord:Bleed and !the_warlord:UrMagic! Weak to ALL enemies that intend to attack this turn."
+    "DESCRIPTION": "Apply !M! the_warlord:Bleed and !the_warlord:UrMagic! Weak to ALL enemies that intend to attack this turn.",
+    "UPGRADE_DESCRIPTION": "Retain. NL Apply !M! the_warlord:Bleed and !the_warlord:UrMagic! Weak to ALL enemies that intend to attack this turn."
   },
 
   "the_warlord:TripleSlash": {

--- a/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Card-Strings.json
+++ b/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Card-Strings.json
@@ -317,7 +317,7 @@
   },
   "the_warlord:Extremespeed": {
     "NAME": "Extremespeed",
-    "DESCRIPTION": "Discard your hand. NL Draw !the_warlord:UrMagic! cards. NL Shuffle !M! *Dizzy into your draw pile."
+    "DESCRIPTION": "Draw !the_warlord:UrMagic! cards. NL Shuffle !M! *Dizzy into your draw pile."
   },
   "the_warlord:CompositeArmor": {
     "NAME": "Composite Armor",

--- a/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Power-Strings.json
+++ b/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Power-Strings.json
@@ -6,7 +6,12 @@
       "Does something #b%1$s times."
     ]
   },
-
+  "the_warlord:AnticoagulantPower": {
+    "NAME": "Anticoagulant",
+    "DESCRIPTIONS": [
+      "Whenever you Parry, apply #b%1$s #yGush to ALL enemies."
+    ]
+  },
   "the_warlord:BleedPower": {
     "NAME": "Bleed",
     "DESCRIPTIONS": [
@@ -70,9 +75,9 @@
     ]
   },
   "the_warlord:ParryPower": {
-    "NAME": "",
+    "NAME": "Parrying Spirit",
     "DESCRIPTIONS": [
-      ""
+      "Whenever an attack removes all of your block, or you take no damage from an attack, parry. Parrying gives you random options from your #yParry #yDeck to play at the start of your next turn (After drawing cards). "
     ]
   },
   "the_warlord:ReactionTimePower": {
@@ -115,7 +120,7 @@
   "the_warlord:FocusPunchPower": {
     "NAME": "Focus Punch",
     "DESCRIPTIONS": [
-      "At the start of next turn, deal #b%1$s damage. NL If you take damage, gain #b5 #yTension."
+      "At the start of next turn, deal #b%1$s damage. NL If you take damage, gain #b2 #yTension."
     ]
   },
 

--- a/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Power-Strings.json
+++ b/src/main/resources/the_warlordResources/localization/eng/WarlordMod-Power-Strings.json
@@ -9,7 +9,7 @@
   "the_warlord:AnticoagulantPower": {
     "NAME": "Anticoagulant",
     "DESCRIPTIONS": [
-      "Whenever you Parry, apply #b%1$s #yGush to ALL enemies."
+      "The next time you parry, apply #b%1$s #yGush to ALL enemies."
     ]
   },
   "the_warlord:BleedPower": {
@@ -120,7 +120,7 @@
   "the_warlord:FocusPunchPower": {
     "NAME": "Focus Punch",
     "DESCRIPTIONS": [
-      "At the start of next turn, deal #b%1$s damage. NL If you take damage, gain #b2 #yTension."
+      "At the start of next turn, deal #b%1$s damage. NL If you take damage, gain #b%2$s #yTension."
     ]
   },
 


### PR DESCRIPTION
Wrap: Gain 5(8) Block, Lose 1 Tension.

Ambush: Deal 10 (13) Damage, If the enemy isn't attacking, gain [E].

Extremespeed: Dizzy amount reduced to 1, Draw reduced to 3(4), Discard clause removed.

Focus Punch cost reduced to 1, damage reduced to 16 (20), Tension reduced to 2.

Anticoagulant: Changed to "When you parry, apply 2 Gush to ALL enemies.", Cost changed to 1(0)

Steamroll: Deal 6(8) Damage and Apply 2(3) Bleed X times.

Decisive Factor: Upgrade changed - Upgrade all cards in your deck (and parry deck) for this combat.

Topsy Turvy: Whenever you gain tension, gain 1(2) Posture.

Ablution - Gain 3(4) block whenever a debuff is removed.

QOL: ParryPower now has a description and is viewable.

